### PR TITLE
Extract targets

### DIFF
--- a/src/game/actors/enemy.rs
+++ b/src/game/actors/enemy.rs
@@ -1,4 +1,3 @@
-use bevy::color::palettes::css;
 use bevy::math::uvec2;
 use bevy::prelude::*;
 use bevy_trauma_shake::TraumaCommands;
@@ -103,7 +102,6 @@ fn move_enemies(
         With<EnemyActor>,
     >,
     q_not_enemy_units: Query<(), Without<EnemyActor>>,
-    mut q_sprites: Query<(&mut Sprite, &mut Visibility)>,
     q_transforms: Query<&Transform, Without<EnemyActor>>,
     mut next_game_state: ResMut<NextState<GameState>>,
     mut next_enemy_action_state: ResMut<NextState<EnemyActionState>>,

--- a/src/game/actors/enemy.rs
+++ b/src/game/actors/enemy.rs
@@ -10,7 +10,6 @@ use crate::game::constants::*;
 use crate::game::cycle::{DayCycle, Season, TimeOfDay, Turn};
 use crate::game::level::Terrain;
 use crate::game::map::VillageMap;
-use crate::game::selection::SelectionMap;
 use crate::game::tile_set::{tile_coord_translation, TileSet, TILE_ANCHOR};
 use crate::game::vfx::{FireOneShotVfx, OneShotVfx};
 use crate::path_finding::tiles::{Tile, TileDir};
@@ -27,7 +26,6 @@ impl Plugin for EnemyActorsPlugin {
         app.init_state::<EnemyActionState>()
             .add_systems(OnEnter(TimeOfDay::Night), spawn_enemies)
             .add_systems(OnEnter(GameState::EnemyTurn), find_movement_path)
-            .add_systems(OnEnter(GameState::BuildingTurn), hide_thick_borders)
             .add_systems(
                 Update,
                 (
@@ -41,23 +39,12 @@ impl Plugin for EnemyActorsPlugin {
     }
 }
 
-/// Hide all thick borders (enemy attack indicators).
-fn hide_thick_borders(mut q_vis: Query<&mut Visibility>, selection_map: Res<SelectionMap>) {
-    for (_, &entity) in selection_map.thick_borders.iter() {
-        if let Ok(mut vis) = q_vis.get_mut(entity) {
-            *vis = Visibility::Hidden;
-        }
-    }
-}
-
 fn perform_attack(
     mut commands: Commands,
     mut q_enemy_attacks: Query<(Entity, &mut EnemyAttack), With<EnemyActor>>,
     q_not_enemy_units: Query<(), Without<EnemyActor>>,
     mut q_health: Query<&mut Health>,
-    mut q_vis: Query<&mut Visibility>,
     village_map: Res<VillageMap>,
-    selection_map: Res<SelectionMap>,
     mut next_enemy_action_state: ResMut<NextState<EnemyActionState>>,
     time: Res<Time>,
     mut evw_oneshot_vfx: EventWriter<FireOneShotVfx>,
@@ -105,14 +92,6 @@ fn perform_attack(
             health.value = health.value.saturating_sub(1);
         }
 
-        // Hide marked tile
-        if let Some(mut vis) = selection_map
-            .thick_borders
-            .get(&enemy_attack.tile)
-            .and_then(|e| q_vis.get_mut(*e).ok())
-        {
-            *vis = Visibility::Hidden;
-        }
         commands.entity(entity).remove::<EnemyAttack>();
     }
 }
@@ -129,7 +108,6 @@ fn move_enemies(
     mut next_game_state: ResMut<NextState<GameState>>,
     mut next_enemy_action_state: ResMut<NextState<EnemyActionState>>,
     mut village_map: ResMut<VillageMap>,
-    selection_map: ResMut<SelectionMap>,
     player_unit_list: Res<PlayerActorList>,
     turn: Res<Turn>,
     time: Res<Time>,
@@ -157,12 +135,6 @@ fn move_enemies(
             }
         }
 
-        // Hide all thick borders
-        for border in selection_map.thick_borders.values() {
-            if let Ok((_, mut vis)) = q_sprites.get_mut(*border) {
-                *vis = Visibility::Hidden;
-            }
-        }
         next_game_state.set(GameState::BuildingTurn);
         return;
     }
@@ -195,16 +167,6 @@ fn move_enemies(
                     commands
                         .entity(entity)
                         .insert(EnemyAttack::new(attack_tile));
-
-                    // Add a red marker for indication
-                    if let Some((mut sprite, mut vis)) = selection_map
-                        .thick_borders
-                        .get(&attack_tile)
-                        .and_then(|e| q_sprites.get_mut(*e).ok())
-                    {
-                        sprite.color = css::RED.into();
-                        *vis = Visibility::Inherited;
-                    }
 
                     // Only 1 object can be attacked at the same time
                     break;

--- a/src/game/actors/enemy.rs
+++ b/src/game/actors/enemy.rs
@@ -400,9 +400,9 @@ impl TilePath {
 
 #[derive(Component, Default, Debug, Clone)]
 pub struct EnemyAttack {
-    tile: Tile,
+    pub tile: Tile,
     /// Animation factor.
-    factor: f32,
+    pub factor: f32,
 }
 
 impl EnemyAttack {

--- a/src/game/cycle.rs
+++ b/src/game/cycle.rs
@@ -153,7 +153,7 @@ fn turn_until_label(
     let section = &mut text.sections[0];
 
     if turn.0 == 0 {
-        section.value = format!("Daytime");
+        section.value = "Daytime".to_string();
     } else {
         section.value = format!("{} turn(s) until {}", turn_left, target_day);
     }

--- a/src/game/level.rs
+++ b/src/game/level.rs
@@ -74,7 +74,6 @@ pub fn load_level(
 
             let (xf, yf) = (x as f32, y as f32);
 
-            let edge_translation = tile_coord_translation(xf, yf, 1.0);
             let object_translation = tile_coord_translation(xf, yf, 2.0);
 
             let (xi, yi) = (x as i32, y as i32);
@@ -90,53 +89,6 @@ pub fn load_level(
             };
 
             village_map.set_terrain(Tile(xi, yi), terrain);
-
-            // // Border
-            // let id = commands
-            //     .spawn((
-            //         SpriteBundle {
-            //             sprite: Sprite {
-            //                 anchor: TILE_ANCHOR,
-            //                 color: YELLOW.into(),
-            //                 ..Default::default()
-            //             },
-            //             texture: tile_set.get("border"),
-            //             transform: Transform {
-            //                 translation: edge_translation + Vec3::Z * 2.0,
-            //                 ..Default::default()
-            //             },
-            //             visibility: Visibility::Hidden,
-            //             ..default()
-            //         },
-            //         StateScoped(Screen::Playing),
-            //         Tile(xi, yi),
-            //         TileBorder,
-            //     ))
-            //     .id();
-            // selection_map.borders.insert(Tile(xi, yi), id);
-            // // Thick border
-            // let id = commands
-            //     .spawn((
-            //         SpriteBundle {
-            //             sprite: Sprite {
-            //                 anchor: TILE_ANCHOR,
-            //                 color: YELLOW.into(),
-            //                 ..Default::default()
-            //             },
-            //             texture: tile_set.get("border_thick"),
-            //             transform: Transform {
-            //                 translation: edge_translation + Vec3::Z,
-            //                 ..Default::default()
-            //             },
-            //             visibility: Visibility::Hidden,
-            //             ..default()
-            //         },
-            //         StateScoped(Screen::Playing),
-            //         Tile(xi, yi),
-            //         TileThickBorder,
-            //     ))
-            //     .id();
-            // selection_map.thick_borders.insert(Tile(xi, yi), id);
 
             if object_tile_name != "empty" {
                 let object_entity = commands.spawn((

--- a/src/game/level.rs
+++ b/src/game/level.rs
@@ -1,6 +1,5 @@
 //! Spawn the main level by triggering other observers.
 
-use bevy::color::palettes::css::YELLOW;
 use bevy::prelude::*;
 
 use crate::game::actors::spawn::SpawnAnimation;
@@ -9,7 +8,7 @@ use crate::path_finding::tiles::{Tile, TileDim};
 use crate::{screen::Screen, VillageCamera};
 
 use super::actors::EnemyActor;
-use super::{picking::PickableTile, selection::SelectionMap};
+use super::picking::PickableTile;
 
 use self::level_asset::{LevelAsset, LevelAssetPlugin, Levels};
 
@@ -54,7 +53,6 @@ pub fn load_level(
         return;
     };
 
-    let mut selection_map = SelectionMap::default();
     let mut village_map = VillageMap::new(TileDim::splat(level_asset.size as i32));
 
     let camera_translation = Vec3::new(
@@ -93,52 +91,52 @@ pub fn load_level(
 
             village_map.set_terrain(Tile(xi, yi), terrain);
 
-            // Border
-            let id = commands
-                .spawn((
-                    SpriteBundle {
-                        sprite: Sprite {
-                            anchor: TILE_ANCHOR,
-                            color: YELLOW.into(),
-                            ..Default::default()
-                        },
-                        texture: tile_set.get("border"),
-                        transform: Transform {
-                            translation: edge_translation + Vec3::Z * 2.0,
-                            ..Default::default()
-                        },
-                        visibility: Visibility::Hidden,
-                        ..default()
-                    },
-                    StateScoped(Screen::Playing),
-                    Tile(xi, yi),
-                    TileBorder,
-                ))
-                .id();
-            selection_map.borders.insert(Tile(xi, yi), id);
-            // Thick border
-            let id = commands
-                .spawn((
-                    SpriteBundle {
-                        sprite: Sprite {
-                            anchor: TILE_ANCHOR,
-                            color: YELLOW.into(),
-                            ..Default::default()
-                        },
-                        texture: tile_set.get("border_thick"),
-                        transform: Transform {
-                            translation: edge_translation + Vec3::Z,
-                            ..Default::default()
-                        },
-                        visibility: Visibility::Hidden,
-                        ..default()
-                    },
-                    StateScoped(Screen::Playing),
-                    Tile(xi, yi),
-                    TileThickBorder,
-                ))
-                .id();
-            selection_map.thick_borders.insert(Tile(xi, yi), id);
+            // // Border
+            // let id = commands
+            //     .spawn((
+            //         SpriteBundle {
+            //             sprite: Sprite {
+            //                 anchor: TILE_ANCHOR,
+            //                 color: YELLOW.into(),
+            //                 ..Default::default()
+            //             },
+            //             texture: tile_set.get("border"),
+            //             transform: Transform {
+            //                 translation: edge_translation + Vec3::Z * 2.0,
+            //                 ..Default::default()
+            //             },
+            //             visibility: Visibility::Hidden,
+            //             ..default()
+            //         },
+            //         StateScoped(Screen::Playing),
+            //         Tile(xi, yi),
+            //         TileBorder,
+            //     ))
+            //     .id();
+            // selection_map.borders.insert(Tile(xi, yi), id);
+            // // Thick border
+            // let id = commands
+            //     .spawn((
+            //         SpriteBundle {
+            //             sprite: Sprite {
+            //                 anchor: TILE_ANCHOR,
+            //                 color: YELLOW.into(),
+            //                 ..Default::default()
+            //             },
+            //             texture: tile_set.get("border_thick"),
+            //             transform: Transform {
+            //                 translation: edge_translation + Vec3::Z,
+            //                 ..Default::default()
+            //             },
+            //             visibility: Visibility::Hidden,
+            //             ..default()
+            //         },
+            //         StateScoped(Screen::Playing),
+            //         Tile(xi, yi),
+            //         TileThickBorder,
+            //     ))
+            //     .id();
+            // selection_map.thick_borders.insert(Tile(xi, yi), id);
 
             if object_tile_name != "empty" {
                 let object_entity = commands.spawn((
@@ -164,7 +162,6 @@ pub fn load_level(
 
     village_map.generate_heat_map(|e| enemies_query.contains(e));
     commands.insert_resource(village_map);
-    commands.insert_resource(selection_map)
 }
 
 #[derive(Component, Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/game/rendering/extract_map.rs
+++ b/src/game/rendering/extract_map.rs
@@ -1,4 +1,5 @@
 use bevy::app::Plugin;
+use bevy::color::palettes::css::RED;
 use bevy::color::palettes::tailwind::YELLOW_300;
 use bevy::math::vec2;
 use bevy::prelude::*;
@@ -9,7 +10,9 @@ use bevy::sprite::ExtractedSprite;
 use bevy::sprite::ExtractedSprites;
 use bevy::sprite::SpriteSystem;
 
+use crate::game::actors::enemy::EnemyAttack;
 use crate::game::actors::stats::Health;
+use crate::game::actors::EnemyActor;
 use crate::game::components::ArcherTower;
 use crate::game::constants;
 use crate::game::constants::CURSOR_COLOR;
@@ -52,6 +55,7 @@ impl Plugin for MapExtractionPlugin {
                 (
                     extract_terrain,
                     extract_selected_tiles,
+                    extract_targeted_tiles,
                     extract_arrow_sprites,
                     extract_tile_cursor,
                     extract_arrow_sprites,
@@ -226,6 +230,37 @@ fn extract_selected_tiles(
                 },
             );
         }
+    }
+}
+
+fn extract_targeted_tiles(
+    mut commands: Commands,
+    mut extracted_sprites: ResMut<ExtractedSprites>,
+    tile_set: Extract<Res<TileSet>>,
+    ent: Extract<Res<MapEnt>>,
+    q_enemy_attacks: Extract<Query<&EnemyAttack, With<EnemyActor>>>,
+) {
+    let border_image = tile_set.get("border_thick");
+
+    for enemy_attack in q_enemy_attacks.iter() {
+        extracted_sprites.sprites.insert(
+            commands.spawn_empty().id(),
+            ExtractedSprite {
+                color: RED.into(),
+                transform: Transform {
+                    translation: tile_to_camera(enemy_attack.tile, 1.1),
+                    ..Default::default()
+                }
+                .into(),
+                rect: None,
+                anchor: TILE_ANCHOR.as_vec(),
+                original_entity: Some(ent.0),
+                custom_size: None,
+                image_handle_id: border_image.id(),
+                flip_x: false,
+                flip_y: false,
+            },
+        );
     }
 }
 

--- a/src/game/selection.rs
+++ b/src/game/selection.rs
@@ -1,10 +1,9 @@
 use bevy::color::palettes::css;
 use bevy::prelude::*;
-use bevy::utils::{HashMap, HashSet};
+use bevy::utils::HashSet;
 
 use super::actors::stats::Movement;
 use super::actors::{ActorTurnState, EnemyActor, PlayerActor};
-use super::audio::soundtrack::PlaySoundtrack;
 use super::components::GroundTileLayer;
 use super::deployment::deploy_unit;
 use super::map::VillageMap;
@@ -19,7 +18,6 @@ pub struct SelectionPlugin;
 impl Plugin for SelectionPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<SelectedTiles>()
-            .init_resource::<SelectionMap>()
             .init_resource::<SelectedActor>()
             .add_event::<SelectionEvent>()
             .add_event::<ObjectPressedEvent>()
@@ -63,12 +61,6 @@ impl SelectedActor {
 pub struct SelectedTiles {
     pub color: Color,
     pub tiles: HashSet<Tile>,
-}
-
-#[derive(Resource, Default)]
-pub struct SelectionMap {
-    pub borders: HashMap<Tile, Entity>,
-    pub thick_borders: HashMap<Tile, Entity>,
 }
 
 fn color_selected_tiles(


### PR DESCRIPTION
Instead of retaining the border target sprite entities, query for enemy attacks and extract sprites directly when tiles are targeted.

Fixes the targets not being removed when attacks aren't completed.